### PR TITLE
Qiita記事からの修正分

### DIFF
--- a/backend/golang/app/cmd/main.go
+++ b/backend/golang/app/cmd/main.go
@@ -31,9 +31,6 @@ func main() {
 	if *f == "migrate" {
 		migrate()
 	}
-	http.HandleFunc("/fetch-todos", ro.FetchTodos)
-	http.HandleFunc("/add-todo", ro.AddTodo)
-	http.HandleFunc("/delete-todo", ro.DeleteTodo)
-	http.HandleFunc("/change-todo", ro.ChangeTodo)
+	ro.HandleRequest()
 	http.ListenAndServe(":8080", nil)
 }

--- a/backend/golang/app/controller/dto/todo_dto.go
+++ b/backend/golang/app/controller/dto/todo_dto.go
@@ -1,0 +1,25 @@
+package dto
+
+// リクエストボディがないので、Requestのdto不要
+type FetchTodoResponse struct {
+    Id     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// レスポンスはSQLの実行結果なので、Responseのdto不要
+type AddTodoRequest struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// レスポンスはSQLの実行結果なので、Responseのdto不要
+type ChangeTodoRequest struct {
+	Id     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// レスポンスはSQLの実行結果なので、Responseのdto不要
+type DeleteTodoRequest struct {
+	Id string `json:"id"`
+}

--- a/backend/golang/app/controller/router.go
+++ b/backend/golang/app/controller/router.go
@@ -6,10 +6,7 @@ import (
 )
 
 type Router interface {
-	FetchTodos(w http.ResponseWriter, r *http.Request)
-	AddTodo(w http.ResponseWriter, r *http.Request)
-	DeleteTodo(w http.ResponseWriter, r *http.Request)
-	ChangeTodo(w http.ResponseWriter, r *http.Request)
+	HandleRequest()
 }
 
 type router struct {
@@ -20,48 +17,31 @@ func CreateRouter(tc TodoController) Router {
 	return &router{tc}
 }
 
-func (ro *router) FetchTodos(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Headers", "*")
-	w.Header().Set("Access-Control-Allow-Origin", os.Getenv("ORIGIN"))
-	w.Header().Set("Content-Type", "application/json")
-	ro.tc.FetchTodos(w, r)
+func (ro *router)HandleRequest() {
+	http.HandleFunc("/todo/", ro.HandleTodoRequest)
 }
 
-func (ro *router) AddTodo(w http.ResponseWriter, r *http.Request) {
+func (ro *router)HandleTodoRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 	w.Header().Set("Access-Control-Allow-Origin", os.Getenv("ORIGIN"))
 	w.Header().Set("Content-Type", "application/json")
 
-	// preflightでAPIが二度実行されてしまうことを防ぐ。
-	if r.Method == "OPTIONS" {
-		return
+    // preflightでAPIが二度実行されてしまうことを防ぐ。
+    if r.Method == "OPTIONS" {
+	return
+    }
+
+	prefix := "/todo/"
+
+	switch r.URL.Path {
+	case prefix + "fetch-todos":
+		ro.tc.FetchTodos(w, r)
+	case prefix + "add-todo":
+		ro.tc.AddTodo(w, r)
+	case prefix + "delete-todo":
+		ro.tc.DeleteTodo(w, r)
+	case prefix + "change-todo":
+		ro.tc.ChangeTodo(w, r)
+	default:
 	}
-
-	ro.tc.AddTodo(w, r)
-}
-
-func (ro *router) DeleteTodo(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Headers", "*")
-	w.Header().Set("Access-Control-Allow-Origin", os.Getenv("ORIGIN"))
-	w.Header().Set("Content-Type", "application/json")
-
-	// preflightでAPIが二度実行されてしまうことを防ぐ。
-	if r.Method == "OPTIONS" {
-		return
-	}
-	
-	ro.tc.DeleteTodo(w, r)
-}
-
-func (ro *router) ChangeTodo(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Headers", "*")
-	w.Header().Set("Access-Control-Allow-Origin", os.Getenv("ORIGIN"))
-	w.Header().Set("Content-Type", "application/json")
-
-	// preflightでAPIが二度実行されてしまうことを防ぐ。
-	if r.Method == "OPTIONS" {
-		return
-	}
-	
-	ro.tc.ChangeTodo(w, r)
 }

--- a/backend/golang/app/controller/router.go
+++ b/backend/golang/app/controller/router.go
@@ -43,5 +43,6 @@ func (ro *router)HandleTodoRequest(w http.ResponseWriter, r *http.Request) {
 	case prefix + "change-todo":
 		ro.tc.ChangeTodo(w, r)
 	default:
+		w.WriteHeader(405)
 	}
 }

--- a/backend/golang/app/controller/router.go
+++ b/backend/golang/app/controller/router.go
@@ -17,19 +17,19 @@ func CreateRouter(tc TodoController) Router {
 	return &router{tc}
 }
 
-func (ro *router)HandleRequest() {
+func (ro *router) HandleRequest() {
 	http.HandleFunc("/todo/", ro.HandleTodoRequest)
 }
 
-func (ro *router)HandleTodoRequest(w http.ResponseWriter, r *http.Request) {
+func (ro *router) HandleTodoRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 	w.Header().Set("Access-Control-Allow-Origin", os.Getenv("ORIGIN"))
 	w.Header().Set("Content-Type", "application/json")
 
-    // preflightでAPIが二度実行されてしまうことを防ぐ。
-    if r.Method == "OPTIONS" {
-	return
-    }
+	// preflightでAPIが二度実行されてしまうことを防ぐ。
+	if r.Method == "OPTIONS" {
+		return
+	}
 
 	prefix := "/todo/"
 

--- a/backend/golang/app/controller/todo_controller.go
+++ b/backend/golang/app/controller/todo_controller.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"crud/controller/dto"
 	"crud/model"
+	"crud/model/entities"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,13 +28,25 @@ func (tc *todoController) FetchTodos(w http.ResponseWriter, r *http.Request) {
 	todos, err := tc.tm.FetchTodos()
 
 	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
 
-	json, err := json.Marshal(todos)
+	var response []dto.FetchTodoResponse
+
+	for _, t := range todos {
+		response = append(response, dto.FetchTodoResponse{
+			Id:     t.Id,
+			Name:   t.Name,
+			Status: t.Status,
+		})
+	}
+
+	json, err := json.Marshal(response)
 
 	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
@@ -41,9 +55,24 @@ func (tc *todoController) FetchTodos(w http.ResponseWriter, r *http.Request) {
 }
 
 func (tc *todoController) AddTodo(w http.ResponseWriter, r *http.Request) {
-	result, err := tc.tm.AddTodo(r)
+	body := make([]byte, r.ContentLength)
+	r.Body.Read(body)
+	var addTodoRequest dto.AddTodoRequest
+	err := json.Unmarshal(body, &addTodoRequest)
 
 	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprint(w, err)
+		return
+	}
+
+	result, err := tc.tm.AddTodo(entities.Todo{
+		Name:   addTodoRequest.Name,
+		Status: addTodoRequest.Status,
+	})
+
+	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
@@ -51,6 +80,7 @@ func (tc *todoController) AddTodo(w http.ResponseWriter, r *http.Request) {
 	json, err := json.Marshal(result)
 
 	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
@@ -59,9 +89,24 @@ func (tc *todoController) AddTodo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (tc *todoController) ChangeTodo(w http.ResponseWriter, r *http.Request) {
-	result, err := tc.tm.ChangeTodo(r)
+	body := make([]byte, r.ContentLength)
+	r.Body.Read(body)
+	var changeTodoRequest dto.ChangeTodoRequest
+	err := json.Unmarshal(body, &changeTodoRequest)
 
 	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprint(w, err)
+		return
+	}
+
+	result, err := tc.tm.ChangeTodo(entities.Todo{
+		Id:     changeTodoRequest.Id,
+		Status: changeTodoRequest.Status,
+	})
+
+	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
@@ -69,6 +114,7 @@ func (tc *todoController) ChangeTodo(w http.ResponseWriter, r *http.Request) {
 	json, err := json.Marshal(result)
 
 	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
@@ -77,9 +123,23 @@ func (tc *todoController) ChangeTodo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (tc *todoController) DeleteTodo(w http.ResponseWriter, r *http.Request) {
-	result, err := tc.tm.DeleteTodo(r)
+	body := make([]byte, r.ContentLength)
+	r.Body.Read(body)
+	var deleteTodoRequest dto.DeleteTodoRequest
+	err := json.Unmarshal(body, &deleteTodoRequest)
 
 	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprint(w, err)
+		return
+	}
+
+	result, err := tc.tm.DeleteTodo(entities.Todo{
+		Id: deleteTodoRequest.Id,
+	})
+
+	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}
@@ -87,6 +147,7 @@ func (tc *todoController) DeleteTodo(w http.ResponseWriter, r *http.Request) {
 	json, err := json.Marshal(result)
 
 	if err != nil {
+		w.WriteHeader(500)
 		fmt.Fprint(w, err)
 		return
 	}

--- a/backend/golang/app/model/entities/todo_entities.go
+++ b/backend/golang/app/model/entities/todo_entities.go
@@ -1,0 +1,7 @@
+package entities
+
+type Todo struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}

--- a/backend/golang/app/model/todo_model.go
+++ b/backend/golang/app/model/todo_model.go
@@ -1,35 +1,29 @@
 package model
 
 import (
+	"crud/model/entities"
 	"database/sql"
 	"math/rand"
-	"net/http"
 	"time"
 
 	"github.com/oklog/ulid"
 )
 
 type TodoModel interface {
-	FetchTodos() ([]*Todo, error)
-	AddTodo(r *http.Request) (sql.Result, error)
-	ChangeTodo(r *http.Request) (sql.Result, error)
-	DeleteTodo(r *http.Request) (sql.Result, error)
+	FetchTodos() ([]*entities.Todo, error)
+	AddTodo(r entities.Todo) (sql.Result, error)
+	ChangeTodo(r entities.Todo) (sql.Result, error)
+	DeleteTodo(r entities.Todo) (sql.Result, error)
 }
 
 type todoModel struct {
-}
-
-type Todo struct {
-	Id     string `json:"id"`
-	Name   string    `json:"name"`
-	Status string    `json:"status"`
 }
 
 func CreateTodoModel() TodoModel {
 	return &todoModel{}
 }
 
-func (tm *todoModel) FetchTodos() ([]*Todo, error) {
+func (tm *todoModel) FetchTodos() ([]*entities.Todo, error) {
 	sql := `SELECT id, name, status FROM todos`
 
 	rows, err := Db.Query(sql)
@@ -38,7 +32,7 @@ func (tm *todoModel) FetchTodos() ([]*Todo, error) {
 	}
 	defer rows.Close()
 
-	var todos []*Todo
+	var todos []*entities.Todo
 
 	for rows.Next() {
 		var (
@@ -49,8 +43,8 @@ func (tm *todoModel) FetchTodos() ([]*Todo, error) {
 			return nil, err
 		}
 
-		todos = append(todos, &Todo{
-			Id: id,
+		todos = append(todos, &entities.Todo{
+			Id:     id,
 			Name:   name,
 			Status: status,
 		})
@@ -59,21 +53,15 @@ func (tm *todoModel) FetchTodos() ([]*Todo, error) {
 	return todos, nil
 }
 
-func (tm *todoModel) AddTodo(r *http.Request) (sql.Result, error) {
-	err := r.ParseForm()
-
-	if err != nil {
-		return nil, nil
-	}
-
+func (tm *todoModel) AddTodo(r entities.Todo) (sql.Result, error) {
 	t := time.Now()
 	entropy := ulid.Monotonic(rand.New(rand.NewSource(t.UnixNano())), 0)
 	id := ulid.MustNew(ulid.Timestamp(t), entropy)
 
-	req := Todo{
+	req := entities.Todo{
 		Id:     id.String(),
-		Name:   r.FormValue("name"),
-		Status: r.FormValue("status"),
+		Name:   r.Name,
+		Status: r.Status,
 	}
 
 	sql := `INSERT INTO todos(id, name, status) VALUES(?, ?, ?)`
@@ -87,21 +75,15 @@ func (tm *todoModel) AddTodo(r *http.Request) (sql.Result, error) {
 	return result, nil
 }
 
-func (tm *todoModel) ChangeTodo(r *http.Request) (sql.Result, error) {
-	err := r.ParseForm()
-
-	if err != nil {
-		return nil, nil
-	}
-
+func (tm *todoModel) ChangeTodo(r entities.Todo) (sql.Result, error) {
 	sql := `UPDATE todos SET status = ? WHERE id = ?`
 
 	afterStatus := "作業中"
-	if r.FormValue("status") == "作業中" {
+	if r.Status == "作業中" {
 		afterStatus = "完了"
 	}
 
-	result, err := Db.Exec(sql, afterStatus, r.FormValue("id"))
+	result, err := Db.Exec(sql, afterStatus, r.Id)
 
 	if err != nil {
 		return result, err
@@ -110,16 +92,10 @@ func (tm *todoModel) ChangeTodo(r *http.Request) (sql.Result, error) {
 	return result, nil
 }
 
-func (tm *todoModel) DeleteTodo(r *http.Request) (sql.Result, error) {
-	err := r.ParseForm()
-
-	if err != nil {
-		return nil, nil
-	}
-
+func (tm *todoModel) DeleteTodo(r entities.Todo) (sql.Result, error) {
 	sql := `DELETE FROM todos WHERE id = ?`
 
-	result, err := Db.Exec(sql, r.FormValue("id"))
+	result, err := Db.Exec(sql, r.Id)
 
 	if err != nil {
 		return result, err

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -18,8 +18,8 @@ export const InputForm = () => {
       status: WORK_ON_PROGRESS,
     }
     const body = new URLSearchParams(todo)
-    await client.post('add-todo', body)
-    client.get('fetch-todos').then(({ data }) => {
+    await client.post('todo/add-todo', body)
+    client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)
     })
   }

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -13,11 +13,10 @@ export const InputForm = () => {
   }
 
   const addTodo = async () => {
-    const todo = {
+    const body = {
       name: todoName,
       status: WORK_ON_PROGRESS,
     }
-    const body = new URLSearchParams(todo)
     await client.post('todo/add-todo', body)
     client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -13,7 +13,7 @@ export const TodoList = () => {
   const { todos, setTodos } = useContext(TodoContext)
 
   useEffect(() => {
-    client.get('fetch-todos').then(({ data }) => {
+    client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)
     })
   }, [])
@@ -22,8 +22,8 @@ export const TodoList = () => {
     const body = new URLSearchParams({
       id,status
     })
-    await client.post('change-todo', body)
-    client.get('fetch-todos').then(({ data }) => {
+    await client.post('todo/change-todo', body)
+    client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)
     })
   }
@@ -32,8 +32,8 @@ export const TodoList = () => {
     const body = new URLSearchParams({
       id,
     })
-    await client.post('delete-todo', body)
-    client.get('fetch-todos').then(({ data }) => {
+    await client.post('todo/delete-todo', body)
+    client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)
     })
   }

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -19,20 +19,14 @@ export const TodoList = () => {
   }, [])
 
   const changeTodo = async (id: string, status: string) => {
-    const body = new URLSearchParams({
-      id,status
-    })
-    await client.post('todo/change-todo', body)
+    await client.post('todo/change-todo', { id, status })
     client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)
     })
   }
 
   const deleteTodo = async (id: string) => {
-    const body = new URLSearchParams({
-      id,
-    })
-    await client.post('todo/delete-todo', body)
+    await client.post('todo/delete-todo', { id })
     client.get('todo/fetch-todos').then(({ data }) => {
       setTodos(data)
     })

--- a/frontend/src/libs/axios.ts
+++ b/frontend/src/libs/axios.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 
+axios.defaults.headers.common['Content-Type'] = 'application/json'
+
 export const client = axios.create({
   baseURL: 'http://localhost:8080/',
 })


### PR DESCRIPTION
### バックエンドの修正
- routerの保守性を向上
    - 修正前は```main.go```にルーティングの詳細を書いてしまってい他ので、```router.go```の中に閉じ込めた。
    - ```router.go```でもタスク管理に関するAPIしかない前提になっていたので、修正。（Ginっぽく書いた）

- controllerの保守性を向上
    - フロントからのリクエストのボディを```model```で取り出してしまっていたので、```controller```で取り出し、```model```に渡す形に変えた。リクエストボディは一旦```dto```に詰め込み、```model```に渡す際には```entities```に定義した構造体に詰め込み直している。
    - エラー発生時にレスポンスヘッダーに500のステータスコードを書き込む。

- modelの保守性を向上
    - フロントからのリクエストボディの取り出しを```controller```に委譲。その分エラーハンドリングを削除。

### フロントの修正
- ```router.go```の修正に伴い、叩きにいくエンドポイントも修正。
- リクエストの```Content-Type```が```aplication/json```になるよう修正。